### PR TITLE
Node groups demo

### DIFF
--- a/packages/react-integration/demo-app-ts/src/Demos.ts
+++ b/packages/react-integration/demo-app-ts/src/Demos.ts
@@ -43,6 +43,11 @@ export const Demos: DemoInterface[] = [
     componentType: Examples.TopologyDashedEdgesDemo
   },
   {
+    id: 'topology-node-group-demo',
+    name: 'Topology Node Group Demo',
+    componentType: Examples.TopologyNodeGroupDemo
+  },
+  {
     id: 'topology-node-shapes-demo',
     name: 'Topology Node Shapes Demo',
     componentType: Examples.TopologyNodeShapesDemo

--- a/packages/react-integration/demo-app-ts/src/components/demos/TopologyNodeGroupDemo/TopologyNodeGroupDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/TopologyNodeGroupDemo/TopologyNodeGroupDemo.tsx
@@ -1,0 +1,74 @@
+import * as React from 'react';
+import { useLayoutFactory, useComponentFactory, useModel, Model } from '@patternfly/react-topology';
+
+import withTopologySetup from '../../../utils/withTopologySetup';
+import defaultComponentFactory from '../../../utils/defaultComponentFactory';
+import defaultLayoutFactory from '../../../utils/defaultLayoutFactory';
+import stylesComponentFactory from '../../../utils/stylesComponentFactory';
+
+export const TopologyNodeGroupDemo: React.FunctionComponent = withTopologySetup(() => {
+  useComponentFactory(defaultComponentFactory);
+  useLayoutFactory(defaultLayoutFactory);
+  useComponentFactory(stylesComponentFactory);
+  useModel(
+    React.useMemo(
+      (): Model => ({
+        graph: {
+          id: 'g1',
+          type: 'graph',
+          layout: 'ColaNoForce'
+        },
+        nodes: [
+          {
+            id: 'n1',
+            type: 'node',
+            width: 75,
+            height: 75
+          },
+          {
+            id: 'n2',
+            type: 'node',
+            width: 75,
+            height: 75
+          },
+          {
+            id: 'n3',
+            type: 'node',
+            width: 75,
+            height: 75
+          },
+          {
+            id: 'Group 1',
+            type: 'group',
+            children: ['n1', 'n2', 'n3'],
+            group: true,
+            label: 'Group 1',
+            style: { padding: 15 },
+            data: {
+              collapsible: false,
+              showContextMenu: false
+            }
+          }
+        ],
+        edges: [
+          {
+            id: 'e1',
+            type: 'edge',
+            source: 'n1',
+            target: 'n3'
+          },
+          {
+            id: 'e2',
+            type: 'edge',
+            source: 'n2',
+            target: 'n1'
+          }
+        ]
+      }),
+      []
+    )
+  );
+  return null;
+});
+
+TopologyNodeGroupDemo.displayName = 'TopologyNodeGroupDemo';

--- a/packages/react-integration/demo-app-ts/src/components/demos/TopologyNodeGroupDemo/TopologyNodeGroupDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/TopologyNodeGroupDemo/TopologyNodeGroupDemo.tsx
@@ -38,14 +38,32 @@ export const TopologyNodeGroupDemo: React.FunctionComponent = withTopologySetup(
             height: 75
           },
           {
+            id: 'n4',
+            type: 'node',
+            width: 75,
+            height: 75
+          },
+          {
             id: 'Group 1',
             type: 'group',
-            children: ['n1', 'n2', 'n3'],
+            children: ['n1', 'n2'],
             group: true,
             label: 'Group 1',
             style: { padding: 15 },
             data: {
               collapsible: false,
+              showContextMenu: false
+            }
+          },
+          {
+            id: 'Group 2',
+            type: 'group',
+            children: ['n3', 'n4'],
+            group: true,
+            label: 'Group 2',
+            style: { padding: 15 },
+            data: {
+              collapsible: true,
               showContextMenu: false
             }
           }

--- a/packages/react-integration/demo-app-ts/src/components/demos/TopologyNodeGroupDemo/TopologyNodeGroupDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/TopologyNodeGroupDemo/TopologyNodeGroupDemo.tsx
@@ -6,86 +6,83 @@ import defaultComponentFactory from '../../../utils/defaultComponentFactory';
 import defaultLayoutFactory from '../../../utils/defaultLayoutFactory';
 import stylesComponentFactory from '../../../utils/stylesComponentFactory';
 
+const dataModel = {
+  graph: {
+    id: 'g1',
+    type: 'graph',
+    layout: 'ColaNoForce'
+  },
+  nodes: [
+    {
+      id: 'n1',
+      type: 'node',
+      width: 75,
+      height: 75
+    },
+    {
+      id: 'n2',
+      type: 'node',
+      width: 75,
+      height: 75
+    },
+    {
+      id: 'n3',
+      type: 'node',
+      width: 75,
+      height: 75
+    },
+    {
+      id: 'n4',
+      type: 'node',
+      width: 75,
+      height: 75
+    },
+    {
+      id: 'Group 1',
+      type: 'group',
+      children: ['n1', 'n2'],
+      group: true,
+      label: 'Group 1',
+      style: { padding: 15 },
+      data: {
+        collapsible: false,
+        showContextMenu: false
+      }
+    },
+    {
+      id: 'Group 2',
+      type: 'group',
+      children: ['n3', 'n4'],
+      group: true,
+      label: 'Group 2',
+      style: { padding: 15 },
+      data: {
+        collapsible: true,
+        showContextMenu: false
+      }
+    }
+  ],
+  edges: [
+    {
+      id: 'e1',
+      type: 'edge',
+      source: 'n1',
+      target: 'n3'
+    },
+    {
+      id: 'e2',
+      type: 'edge',
+      source: 'n2',
+      target: 'n1'
+    }
+  ]
+};
+
 export const TopologyNodeGroupDemo: React.FunctionComponent = withTopologySetup(() => {
   useComponentFactory(defaultComponentFactory);
   useLayoutFactory(defaultLayoutFactory);
   useComponentFactory(stylesComponentFactory);
-  useModel(
-    React.useMemo(
-      (): Model => ({
-        graph: {
-          id: 'g1',
-          type: 'graph',
-          layout: 'ColaNoForce'
-        },
-        nodes: [
-          {
-            id: 'n1',
-            type: 'node',
-            width: 75,
-            height: 75
-          },
-          {
-            id: 'n2',
-            type: 'node',
-            width: 75,
-            height: 75
-          },
-          {
-            id: 'n3',
-            type: 'node',
-            width: 75,
-            height: 75
-          },
-          {
-            id: 'n4',
-            type: 'node',
-            width: 75,
-            height: 75
-          },
-          {
-            id: 'Group 1',
-            type: 'group',
-            children: ['n1', 'n2'],
-            group: true,
-            label: 'Group 1',
-            style: { padding: 15 },
-            data: {
-              collapsible: false,
-              showContextMenu: false
-            }
-          },
-          {
-            id: 'Group 2',
-            type: 'group',
-            children: ['n3', 'n4'],
-            group: true,
-            label: 'Group 2',
-            style: { padding: 15 },
-            data: {
-              collapsible: true,
-              showContextMenu: false
-            }
-          }
-        ],
-        edges: [
-          {
-            id: 'e1',
-            type: 'edge',
-            source: 'n1',
-            target: 'n3'
-          },
-          {
-            id: 'e2',
-            type: 'edge',
-            source: 'n2',
-            target: 'n1'
-          }
-        ]
-      }),
-      []
-    )
-  );
+  useModel(React.useMemo((): Model => dataModel, []));
   return null;
 });
 

--- a/packages/react-integration/demo-app-ts/src/components/demos/index.ts
+++ b/packages/react-integration/demo-app-ts/src/components/demos/index.ts
@@ -5,3 +5,4 @@ export * from './TopologySimpleGraphClassDemo/TopologySimpleGraphClassDemo';
 export * from './TopologySimpleGraphHooksDemo/TopologySimpleGraphHooksDemo';
 export * from './TopologyControlBarDemo/TopologyControlBarDemo';
 export * from './TopologyNodeShapesDemo/TopologyNodeShapesDemo';
+export * from './TopologyNodeGroupDemo/TopologyNodeGroupDemo';

--- a/packages/react-integration/demo-app-ts/src/utils/StyleGroup.tsx
+++ b/packages/react-integration/demo-app-ts/src/utils/StyleGroup.tsx
@@ -1,0 +1,93 @@
+import * as React from 'react';
+import {
+  DefaultGroup,
+  Node,
+  observer,
+  ScaleDetailsLevel,
+  ShapeProps,
+  WithContextMenuProps,
+  WithDragNodeProps,
+  WithSelectionProps
+} from '@patternfly/react-topology';
+import AlternateIcon from '@patternfly/react-icons/dist/esm/icons/regions-icon';
+import DefaultIcon from '@patternfly/react-icons/dist/esm/icons/builder-image-icon';
+import useDetailsLevel from '@patternfly/react-topology/dist/esm/hooks/useDetailsLevel';
+
+const ICON_PADDING = 20;
+
+export enum DataTypes {
+  Default,
+  Alternate
+}
+
+type StyleGroupProps = {
+  element: Node;
+  collapsible: boolean;
+  collapsedWidth?: number;
+  collapsedHeight?: number;
+  onCollapseChange?: (group: Node, collapsed: boolean) => void;
+  getCollapsedShape?: (node: Node) => React.FunctionComponent<ShapeProps>;
+  collapsedShadowOffset?: number; // defaults to 10
+} & WithContextMenuProps &
+  WithDragNodeProps &
+  WithSelectionProps;
+
+const StyleGroup: React.FunctionComponent<StyleGroupProps> = ({
+  element,
+  onContextMenu,
+  contextMenuOpen,
+  collapsedWidth = 75,
+  collapsedHeight = 75,
+  ...rest
+}) => {
+  const data = element.getData();
+  const detailsLevel = useDetailsLevel();
+
+  const getTypeIcon = (dataType?: DataTypes): any => {
+    switch (dataType) {
+      case DataTypes.Alternate:
+        return AlternateIcon;
+      default:
+        return DefaultIcon;
+    }
+  };
+
+  const renderIcon = (): React.ReactNode => {
+    const iconSize = Math.min(collapsedWidth, collapsedHeight) - ICON_PADDING * 2;
+    const Component = getTypeIcon(data.dataType);
+
+    return (
+      <g transform={`translate(${(collapsedWidth - iconSize) / 2}, ${(collapsedHeight - iconSize) / 2})`}>
+        <Component style={{ color: '#393F44' }} width={iconSize} height={iconSize} />
+      </g>
+    );
+  };
+
+  const passedData = React.useMemo(() => {
+    const newData = { ...data };
+    Object.keys(newData).forEach(key => {
+      if (newData[key] === undefined) {
+        delete newData[key];
+      }
+    });
+    return newData;
+  }, [data]);
+
+  return (
+    <DefaultGroup
+      onContextMenu={data.showContextMenu ? onContextMenu : undefined}
+      contextMenuOpen={contextMenuOpen}
+      element={element}
+      collapsible
+      collapsedWidth={collapsedWidth}
+      collapsedHeight={collapsedHeight}
+      showLabel={detailsLevel === ScaleDetailsLevel.high}
+      {...rest}
+      {...passedData}
+    >
+      {element.isCollapsed() ? renderIcon() : null}
+    </DefaultGroup>
+  );
+};
+
+export default observer(StyleGroup);

--- a/packages/react-integration/demo-app-ts/src/utils/defaultComponentFactory.tsx
+++ b/packages/react-integration/demo-app-ts/src/utils/defaultComponentFactory.tsx
@@ -1,21 +1,12 @@
 import { ComponentType } from 'react';
 import { GraphElement, ComponentFactory, ModelKind, GraphComponent, DefaultNode } from '@patternfly/react-topology';
 import Edge from './DefaultEdge';
-// import MultiEdge from './MultiEdge';
-// import Group from './DefaultGroup';
-// import GroupHull from './GroupHull';
 
 const defaultComponentFactory: ComponentFactory = (
   kind: ModelKind,
   type: string
 ): ComponentType<{ element: GraphElement }> => {
   switch (type) {
-    // case 'multi-edge':
-    //   return MultiEdge;
-    // case 'group':
-    //   return Group;
-    // case 'group-hull':
-    //   return GroupHull;
     default:
       switch (kind) {
         case ModelKind.graph:

--- a/packages/react-integration/demo-app-ts/src/utils/stylesComponentFactory.tsx
+++ b/packages/react-integration/demo-app-ts/src/utils/stylesComponentFactory.tsx
@@ -2,9 +2,13 @@ import * as React from 'react';
 import {
   GraphElement,
   ComponentFactory,
+  withContextMenu,
+  ContextMenuSeparator,
+  ContextMenuItem,
   withDragNode,
   withSelection,
   ModelKind,
+  // DragObjectWithType,
   Node,
   withPanZoom,
   GraphComponent,
@@ -12,17 +16,43 @@ import {
   Graph,
   isNode,
   withDndDrop,
+  // Edge,
+  // withTargetDrag,
+  // withSourceDrag,
   nodeDragSourceSpec,
   nodeDropTargetSpec,
+  groupDropTargetSpec,
   graphDropTargetSpec,
   NODE_DRAG_TYPE,
   CREATE_CONNECTOR_DROP_TYPE
 } from '@patternfly/react-topology';
 import StyleNode from './StyleNode';
+import StyleGroup from './StyleGroup';
+// import StyleEdge from './StyleEdge';
 import CustomPathNode from './CustomPathNode';
 
 const CONNECTOR_SOURCE_DROP = 'connector-src-drop';
 const CONNECTOR_TARGET_DROP = 'connector-target-drop';
+
+// interface EdgeProps {
+//   element: Edge;
+// }
+
+const contextMenuItem = (label: string, i: number): React.ReactElement => {
+  if (label === '-') {
+    return <ContextMenuSeparator key={`separator:${i.toString()}`} />;
+  }
+  return (
+    // eslint-disable-next-line no-alert
+    <ContextMenuItem key={label} onClick={() => alert(`Selected: ${label}`)}>
+      {label}
+    </ContextMenuItem>
+  );
+};
+
+const createContextMenuItems = (...labels: string[]): React.ReactElement[] => labels.map(contextMenuItem);
+
+const defaultMenu = createContextMenuItems('First', 'Second', 'Third', '-', 'Fourth');
 
 const stylesComponentFactory: ComponentFactory = (
   kind: ModelKind,
@@ -54,11 +84,56 @@ const stylesComponentFactory: ComponentFactory = (
         source.getController().fromModel(model);
       })(
         withDndDrop(nodeDropTargetSpec([CONNECTOR_SOURCE_DROP, CONNECTOR_TARGET_DROP, CREATE_CONNECTOR_DROP_TYPE]))(
-          withDragNode(nodeDragSourceSpec('node', true, true))(withSelection()(StyleNode))
+          withContextMenu(() => defaultMenu)(
+            withDragNode(nodeDragSourceSpec('node', true, true))(withSelection()(StyleNode))
+          )
         )
       );
     case 'node-path':
       return CustomPathNode;
+    // case 'node-polygon':
+    //   return CustomPolygonNode;
+    case 'group':
+      return withDndDrop(groupDropTargetSpec)(
+        withContextMenu(() => defaultMenu)(withDragNode(nodeDragSourceSpec('group'))(withSelection()(StyleGroup)))
+      );
+    // case 'edge':
+    //   return withSourceDrag<DragObjectWithType, Node, any, EdgeProps>({
+    //     item: { type: CONNECTOR_SOURCE_DROP },
+    //     begin: (monitor, props) => {
+    //       props.element.raise();
+    //       return props.element;
+    //     },
+    //     drag: (event, monitor, props) => {
+    //       props.element.setStartPoint(event.x, event.y);
+    //     },
+    //     end: (dropResult, monitor, props) => {
+    //       if (monitor.didDrop() && dropResult && props) {
+    //         props.element.setSource(dropResult);
+    //       }
+    //       props.element.setStartPoint();
+    //     }
+    //   })(
+    //     withTargetDrag<DragObjectWithType, Node, { dragging?: boolean }, EdgeProps>({
+    //       item: { type: CONNECTOR_TARGET_DROP },
+    //       begin: (monitor, props) => {
+    //         props.element.raise();
+    //         return props.element;
+    //       },
+    //       drag: (event, monitor, props) => {
+    //         props.element.setEndPoint(event.x, event.y);
+    //       },
+    //       end: (dropResult, monitor, props) => {
+    //         if (monitor.didDrop() && dropResult && props) {
+    //           props.element.setTarget(dropResult);
+    //         }
+    //         props.element.setEndPoint();
+    //       },
+    //       collect: monitor => ({
+    //         dragging: monitor.isDragging()
+    //       })
+    //     })(withContextMenu(() => defaultMenu)(withSelection()(StyleEdge)))
+    //   );
     default:
       return undefined;
   }


### PR DESCRIPTION
as it says -- i couldn't find a difference between using the `group` switch statement to render the `DefaultGroup` component like in the big demo vs leaving it out and just relying on the styling one instead, so i left it out 🤷🏼‍♀️  the functionality seems to remain the same too regarding the collapsible/hover/select