### PR TITLE
feat: added demo for edge colors

### DIFF
--- a/packages/react-integration/demo-app-ts/src/Demos.ts
+++ b/packages/react-integration/demo-app-ts/src/Demos.ts
@@ -71,6 +71,11 @@ export const Demos: DemoInterface[] = [
     id: 'topology-edge-terminal-demo',
     name: 'Topology Edge Terminal Demo',
     componentType: Examples.TopologyEdgeTerminalDemo
+  },
+  {
+    id: 'topology-edge-color-demo',
+    name: 'Topology Edge Color Demo',
+    componentType: Examples.TopologyEdgeColorDemo
   }
 ];
 

--- a/packages/react-integration/demo-app-ts/src/components/demos/TopologyEdgeColorDemo/CustomEdge.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/TopologyEdgeColorDemo/CustomEdge.tsx
@@ -1,0 +1,168 @@
+import React from 'react';
+import { css } from '@patternfly/react-styles';
+import styles from '@patternfly/react-styles/css/components/Topology/topology-components';
+import {
+  DefaultConnectorTerminal,
+  Edge,
+  EdgeTerminalType,
+  getEdgeAnimationDuration,
+  getEdgeStyleClassModifier,
+  Layer,
+  NodeStatus,
+  Point,
+  TOP_LAYER,
+  useHover,
+  WithContextMenuProps,
+  WithRemoveConnectorProps,
+  WithSelectionProps,
+  WithSourceDragProps,
+  WithTargetDragProps
+} from '@patternfly/react-topology';
+import _ from 'lodash';
+
+type BaseEdgeProps = {
+  children?: React.ReactNode;
+  element: Edge;
+  dragging?: boolean;
+  className?: string;
+  animationDuration?: number;
+  startTerminalType?: EdgeTerminalType;
+  startTerminalClass?: string;
+  startTerminalStatus?: NodeStatus;
+  startTerminalSize?: number;
+  endTerminalType?: EdgeTerminalType;
+  endTerminalClass?: string;
+  endTerminalStatus?: NodeStatus;
+  endTerminalSize?: number;
+  tag?: string;
+  tagClass?: string;
+  tagStatus?: NodeStatus;
+} & Partial<
+  WithRemoveConnectorProps & WithSourceDragProps & WithTargetDragProps & WithSelectionProps & WithContextMenuProps
+>;
+
+export const getConnectorStartPoint = (startPoint: Point, endPoint: Point, size: number): [number, number] => {
+  const length = Math.sqrt((endPoint.x - startPoint.x) ** 2 + (endPoint.y - startPoint.y) ** 2);
+  if (!length) {
+    return [0, 0];
+  }
+  const ratio = (length - size) / length;
+
+  return [startPoint.x + (endPoint.x - startPoint.x) * ratio, startPoint.y + (endPoint.y - startPoint.y) * ratio];
+};
+
+const CustomEdge: React.FunctionComponent<BaseEdgeProps> = ({
+  element,
+  dragging,
+  sourceDragRef,
+  targetDragRef,
+  animationDuration,
+  onShowRemoveConnector,
+  onHideRemoveConnector,
+  startTerminalType = EdgeTerminalType.none,
+  startTerminalClass,
+  startTerminalStatus,
+  startTerminalSize = 14,
+  endTerminalType = EdgeTerminalType.directional,
+  endTerminalClass,
+  endTerminalStatus,
+  endTerminalSize = 14,
+  children,
+  className,
+  selected,
+  onSelect,
+  onContextMenu
+}) => {
+  const [hover, hoverRef] = useHover();
+  const startPoint = element.getStartPoint();
+  const endPoint = element.getEndPoint();
+
+  // eslint-disable-next-line patternfly-react/no-layout-effect
+  React.useLayoutEffect(() => {
+    if (hover && !dragging) {
+      onShowRemoveConnector && onShowRemoveConnector();
+    } else {
+      onHideRemoveConnector && onHideRemoveConnector();
+    }
+  }, [hover, dragging, onShowRemoveConnector, onHideRemoveConnector]);
+
+  const groupClassName = css(
+    styles.topologyEdge,
+    className,
+    dragging && 'pf-m-dragging',
+    hover && !dragging && 'pf-m-hover',
+    selected && !dragging && 'pf-m-selected'
+  );
+
+  const edgeAnimationDuration = animationDuration ?? getEdgeAnimationDuration(element.getEdgeAnimationSpeed());
+  const linkClassName = css(styles.topologyEdgeLink, getEdgeStyleClassModifier(element.getEdgeStyle()));
+
+  const bendpoints = element.getBendpoints();
+
+  const d = `M${startPoint.x} ${startPoint.y} ${bendpoints.map((b: Point) => `L${b.x} ${b.y} `).join('')}L${
+    endPoint.x
+  } ${endPoint.y}`;
+
+  const bgStartPoint =
+    !startTerminalType || startTerminalType === EdgeTerminalType.none
+      ? [startPoint.x, startPoint.y]
+      : getConnectorStartPoint(_.head(bendpoints) || endPoint, startPoint, startTerminalSize);
+  const bgEndPoint =
+    !endTerminalType || endTerminalType === EdgeTerminalType.none
+      ? [endPoint.x, endPoint.y]
+      : getConnectorStartPoint(_.last(bendpoints) || startPoint, endPoint, endTerminalSize);
+  const backgroundPath = `M${bgStartPoint[0]} ${bgStartPoint[1]} ${bendpoints
+    .map((b: Point) => `L${b.x} ${b.y} `)
+    .join('')}L${bgEndPoint[0]} ${bgEndPoint[1]}`;
+
+  const edgeColor = element?.getData()?.edgeColor || undefined;
+
+  return (
+    <Layer id={dragging || hover ? TOP_LAYER : undefined}>
+      <g
+        ref={hoverRef}
+        data-test-id="edge-handler"
+        className={groupClassName}
+        onClick={onSelect}
+        onContextMenu={onContextMenu}
+      >
+        <path
+          className={css(styles.topologyEdgeBackground)}
+          d={backgroundPath}
+          onMouseEnter={onShowRemoveConnector}
+          onMouseLeave={onHideRemoveConnector}
+        />
+        <path
+          className={linkClassName}
+          d={d}
+          style={{ animationDuration: `${edgeAnimationDuration}s`, stroke: edgeColor }}
+        />
+        <DefaultConnectorTerminal
+          className={startTerminalClass}
+          isTarget={false}
+          edge={element}
+          size={startTerminalSize}
+          dragRef={sourceDragRef}
+          terminalType={startTerminalType}
+          status={startTerminalStatus}
+          highlight={dragging || hover}
+        />
+        <DefaultConnectorTerminal
+          className={endTerminalClass}
+          isTarget
+          dragRef={targetDragRef}
+          edge={element}
+          size={endTerminalSize}
+          terminalType={endTerminalType}
+          status={endTerminalStatus}
+          highlight={dragging || hover}
+        />
+        {children}
+      </g>
+    </Layer>
+  );
+};
+
+CustomEdge.displayName = 'CustomEdge';
+
+export default CustomEdge;

--- a/packages/react-integration/demo-app-ts/src/components/demos/TopologyEdgeColorDemo/TopologyEdgeColorDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/TopologyEdgeColorDemo/TopologyEdgeColorDemo.tsx
@@ -1,0 +1,117 @@
+import React from 'react';
+import {
+  EdgeStyle,
+  TopologyView,
+  VisualizationProvider,
+  VisualizationSurface,
+  useComponentFactory,
+  NodeShape,
+  NodeStatus,
+  useModel,
+  ComponentFactory,
+  ModelKind,
+  DefaultNode,
+  GraphComponent,
+  Model
+} from '@patternfly/react-topology';
+
+import '../TopologyDemo/TopologyDemo.css';
+import CustomEdge from './CustomEdge';
+
+const model: Model = {
+  graph: {
+    id: 'g1',
+    type: 'graph'
+  },
+  nodes: [
+    {
+      height: 75,
+      width: 75,
+      id: 'default-1',
+      label: 'Node 1',
+      shape: NodeShape.ellipse,
+      status: NodeStatus.default,
+      type: 'node',
+      x: 60,
+      y: 20
+    },
+    {
+      height: 75,
+      width: 75,
+      id: 'default-2',
+      label: 'Node 2',
+      shape: NodeShape.ellipse,
+      status: NodeStatus.default,
+      type: 'node',
+      x: 360,
+      y: 20
+    },
+    {
+      height: 75,
+      width: 75,
+      id: 'default-3',
+      label: 'Node 3',
+      shape: NodeShape.ellipse,
+      status: NodeStatus.default,
+      type: 'node',
+      x: 60,
+      y: 270
+    }
+  ],
+  edges: [
+    {
+      id: 'edge-default-2-default-1',
+      type: 'edge',
+      source: 'default-2',
+      target: 'default-1',
+      edgeStyle: EdgeStyle.default,
+      data: {
+        edgeColor: 'green'
+      }
+    },
+    {
+      id: 'edge-default-2-default-3',
+      type: 'edge',
+      source: 'default-2',
+      target: 'default-3',
+      edgeStyle: EdgeStyle.default,
+      data: {
+        edgeColor: 'red'
+      }
+    }
+  ]
+};
+const TopologyComponent = () => {
+  useComponentFactory(
+    React.useCallback<ComponentFactory>((kind, type) => {
+      if (type === ModelKind.graph) {
+        return GraphComponent;
+      }
+      if (type === ModelKind.node) {
+        return DefaultNode;
+      }
+      if (type === ModelKind.edge) {
+        return CustomEdge;
+      }
+      return undefined;
+    }, [])
+  );
+
+  useModel(model);
+
+  return (
+    <TopologyView>
+      <VisualizationSurface />
+    </TopologyView>
+  );
+};
+
+export const TopologyEdgeColorDemo: React.FunctionComponent = React.memo(() => (
+  <div className="pf-ri__topology-demo">
+    <VisualizationProvider>
+      <TopologyComponent />
+    </VisualizationProvider>
+  </div>
+));
+
+TopologyEdgeColorDemo.displayName = 'TopologyEdgeColorDemo';

--- a/packages/react-integration/demo-app-ts/src/components/demos/index.ts
+++ b/packages/react-integration/demo-app-ts/src/components/demos/index.ts
@@ -2,6 +2,7 @@ export * from './TopologyDemo/TopologyDemo';
 export * from './TopologyDemo/TopologySidePanelDemo';
 export * from './TopologyDemo/TopologyDashedEdgesDemo';
 export * from './TopologyDemo/TopologyEdgeTerminalDemo';
+export * from './TopologyEdgeColorDemo/TopologyEdgeColorDemo';
 export * from './TopologySimpleGraphClassDemo/TopologySimpleGraphClassDemo';
 export * from './TopologySimpleGraphHooksDemo/TopologySimpleGraphHooksDemo';
 export * from './TopologyControlBarDemo/TopologyControlBarDemo';


### PR DESCRIPTION
This PR adds a demo for colored edges. I also created a `CustomEdge` component which is basically just the `DefaultEdge` component but with a few alterations:

1. We access the `element.data.colorEdge` to determine what color to color the edge
2. We use the `colorEdge` value to color the `stroke` of an `SVG path`

We can basically modify this component however we see fit using the `data` field. I tried to add the `colorEdge` as a sibling field to the `data` field but that required modifying the types. We could do that, but it'll be quite a few more alterations. Let me know what you think

<img width="1440" alt="Screen Shot 2022-10-04 at 3 34 02 PM" src="https://user-images.githubusercontent.com/4805485/193942402-1c4ff6b2-d0de-4a8c-bec8-bbaf722f9cb4.png">